### PR TITLE
Grub splash

### DIFF
--- a/bin/GoboLinuxInstaller
+++ b/bin/GoboLinuxInstaller
@@ -259,6 +259,8 @@ class BootLoader :
 	def createGrubConfig(self, grubdir) :
 		if len(grubdir) :
 			self.__fixDevRoot()
+			safeRun('mkdir -p %s/%s/images' %(self.destMountPoint,grubdir))
+			shutil.copy('/Programs/GRUB-EFI/Current/share/grub/images/gobo_splash.png', self.destMountPoint+'/'+grubdir+'/images/gobo_splash.png')
 			cmd = 'chroot %s GenGrubConf %s' %(self.destMountPoint, grubdir)
 			safeRun(cmd, 'Running GenGrubConf', 0, self.logger)
 			self.__rollbackDevRoot()

--- a/bin/GoboLinuxInstaller
+++ b/bin/GoboLinuxInstaller
@@ -260,7 +260,7 @@ class BootLoader :
 		if len(grubdir) :
 			self.__fixDevRoot()
 			safeRun('mkdir -p %s/%s/images' %(self.destMountPoint,grubdir))
-			shutil.copy('/Programs/GRUB-EFI/Current/share/grub/images/gobo_splash.png', self.destMountPoint+'/'+grubdir+'/images/gobo_splash.png')
+			shutil.copy('/usr/share/grub/images/gobo_splash.png', self.destMountPoint+'/'+grubdir+'/images/gobo_splash.png')
 			cmd = 'chroot %s GenGrubConf %s' %(self.destMountPoint, grubdir)
 			safeRun(cmd, 'Running GenGrubConf', 0, self.logger)
 			self.__rollbackDevRoot()

--- a/bin/GoboLinuxInstaller
+++ b/bin/GoboLinuxInstaller
@@ -260,7 +260,7 @@ class BootLoader :
 		if len(grubdir) :
 			self.__fixDevRoot()
 			safeRun('mkdir -p %s/%s/images' %(self.destMountPoint,grubdir))
-			shutil.copy('/usr/share/grub/images/gobo_splash.png', self.destMountPoint+'/'+grubdir+'/images/gobo_splash.png')
+			shutil.copy('/System/Index/share/grub/images/gobo_splash.png', self.destMountPoint+'/'+grubdir+'/images/gobo_splash.png')
 			cmd = 'chroot %s GenGrubConf %s' %(self.destMountPoint, grubdir)
 			safeRun(cmd, 'Running GenGrubConf', 0, self.logger)
 			self.__rollbackDevRoot()

--- a/bin/GoboLinuxInstaller
+++ b/bin/GoboLinuxInstaller
@@ -1230,8 +1230,8 @@ def _RunInstallation():
 	if installer.getValue('InstallBootloader') and platform.pureEFI() :
 		log(tr('Installing EFI application on %s' %bootloaderTarget))
 		diskutil.mount(os.path.basename(bootloaderTarget), destMountPoint+'/System/Kernel/ESP')
-		bootloader.createGrubConfig('/System/Kernel/ESP/grub')
 		bootloader.createEFIConfig('/System/Kernel/ESP', '/System/Kernel/ESP')
+		bootloader.createGrubConfig('/System/Kernel/ESP/grub')
 		diskutil.unmount(os.path.basename(bootloaderTarget), destMountPoint+'/System/Kernel/ESP')
 	elif installer.getValue('InstallBootloader') :
 		log(tr('Installing GRUB'))


### PR DESCRIPTION
In tandem with https://github.com/gobolinux/Recipes/pull/257, install grub's gobo splash/background image by default on install.

Installs the image to `grubdir/images/gobo_splash.png` and relies on `05_gobo_theme` to set it as the background.